### PR TITLE
fix: make taggingStatus optional in Bookmark model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/__pycache__
 .env*
 *.egg-info
+build/
 *author*
 **/*log
 **/*.temp

--- a/karakeep_python_api/datatypes.py
+++ b/karakeep_python_api/datatypes.py
@@ -114,7 +114,7 @@ class Bookmark(BaseModel):
     title: Optional[str] = None
     archived: bool
     favourited: bool
-    taggingStatus: Literal["success", "failure", "pending"]
+    taggingStatus: Optional[Literal["success", "failure", "pending"]] = None
     summarizationStatus: Optional[Literal["success", "failure", "pending"]] = None
     note: Optional[str] = None
     summary: Optional[str] = None


### PR DESCRIPTION
Summary

This PR fixes a response validation mismatch in the Python client for bookmarks.

Problem

GET /bookmarks/{bookmarkId} can return "taggingStatus": null for some bookmarks.
The OpenAPI schema marks this field as nullable, but the client model currently requires a non-null literal ("success" |
"failure" | "pending"), which raises a Pydantic validation error.

Fix

Updated Bookmark.taggingStatus in karakeep_python_api/datatypes.py from:

Literal["success", "failure", "pending"]

to:

Optional[Literal["success", "failure", "pending"]] = None

Why this is correct

- Matches server behavior (taggingStatus may be null)
- Matches the package OpenAPI reference (nullable: true)
- Prevents false-negative client failures on valid API responses

Impact

- Backward-compatible type relaxation
- No behavior change for non-null values
- Fixes karakeep get-a-single-bookmark --bookmark-id <id> failing on valid bookmarks with null taggingStatus